### PR TITLE
feat: use env variables for eoa_signing_key and exchange_jwt

### DIFF
--- a/bin/ethgas_commit.rs
+++ b/bin/ethgas_commit.rs
@@ -260,7 +260,7 @@ impl EthgasCommitService {
 
                     match res_json_request.data.message {
                         Some(api_validator_request_response_data_message) => {
-                            let info = RegisteredInfo { 
+                            let info = RegisteredInfo {
                                 address: api_validator_request_response_data_message.address
                             };
                             let request = SignConsensusRequest::builder(pubkey).with_msg(&info);
@@ -332,7 +332,7 @@ async fn main() -> Result<()> {
 
             let exchange_jwt: String;
             if config.extra.is_jwt_provided == false {
-                let exchange_service = EthgasExchangeService { 
+                let exchange_service = EthgasExchangeService {
                     exchange_api_base: config.extra.exchange_api_base.clone(),
                     chain_id: config.extra.chain_id.clone(),
                     entity_name: config.extra.entity_name.clone(),
@@ -352,8 +352,8 @@ async fn main() -> Result<()> {
                                 },
                                 Err(_) => {
                                     error!("Config eoa_signing_key is required. Please set EOA_SIGNING_KEY environment variable or provide it in the config file");
-                            return Err(std::io::Error::new(std::io::ErrorKind::Other,
-                            "eoa_signing_key missing").into());
+                                    return Err(std::io::Error::new(std::io::ErrorKind::Other,
+                                    "eoa_signing_key missing").into());
                                 }
                             }
                         }
@@ -370,9 +370,14 @@ async fn main() -> Result<()> {
                 exchange_jwt = match config.extra.exchange_jwt.clone() {
                     Some(jwt) => jwt,
                     None => {
-                        error!("Config exchange_jwt is required but missing");
-                        return Err(std::io::Error::new(std::io::ErrorKind::Other,
-                                                       "exchange_jwt missing").into());
+                        match env::var("EXCHANGE_JWT") {
+                            Ok(jwt) => jwt,
+                            Err(_) => {
+                                error!("Config exchange_jwt is required. Please set EXCHANGE_JWT environment variable or provide it in the config file");
+                                return Err(std::io::Error::new(std::io::ErrorKind::Other,
+                                "exchange_jwt missing").into());
+                            }
+                        }
                     }
                 };
             }


### PR DESCRIPTION
# Description

👋 team,

Some properties like `eoa_signing_key` or `exchange_jwt` are sensitive. The purpose of this PR is to allow us to configure those properties via environment variables.