### PR TITLE
fix: use warning message to notify when a key is already registered

### DIFF
--- a/bin/ethgas_commit.rs
+++ b/bin/ethgas_commit.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use lazy_static::lazy_static;
 use prometheus::{IntCounter, Registry};
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use std::{time::Duration, error::Error};
 use reqwest::Client;
 use tokio::time::sleep;
@@ -292,7 +292,7 @@ impl EthgasCommitService {
                                 error!("fail to register");
                             }
                         },
-                        None => error!("this pubkey has been registered already"),
+                        None => warn!("this pubkey has been registered already"),
                     }
                 },
                 Err(err) => {


### PR DESCRIPTION
# Description

👋 team,

The purpose of this PR is straightforward: it changes the behavior from throwing an error to displaying a warning message when a key has already been registered. This adjustment prevents the program to crash.